### PR TITLE
Update "aws" and "random" provider versions

### DIFF
--- a/driver-kafka/deploy/provision-kafka-aws.tf
+++ b/driver-kafka/deploy/provision-kafka-aws.tf
@@ -1,10 +1,10 @@
 provider "aws" {
   region  = "${var.region}"
-  version = "1.8"
+  version = "~> 2.7"
 }
 
 provider "random" {
-  version = "1.1"
+  version = "~> 2.1"
 }
 
 variable "public_key_path" {


### PR DESCRIPTION
To be compatible with Terraform 0.12.9.

Following the official instructions for kafka from a scratch install with the latest terraform version, you get errors on the "terraform init" command complaining about the versions of these providers, and the error message suggests this change.  After making the change the init succeeds.